### PR TITLE
Fixed circular dependency caused by .csproj.user in example file

### DIFF
--- a/REPOLib/REPOLib.csproj.user.example
+++ b/REPOLib/REPOLib.csproj.user.example
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
     <!-- COPY THIS FILE AND EDIT THESE SETTINGS -->
     <PropertyGroup>
         <!-- Gale profile name -->


### PR DESCRIPTION
Small fix that removes the `Sdk="Microsoft.NET.Sdk"` from the `<Project>` tag in the `.csproj.user.example` file added by #6 as it causes a circular dependency that prevents the project from loading when used. 