### PR TITLE
Add changelog field to Mod asset

### DIFF
--- a/REPOLib/Objects/Sdk/Mod.cs
+++ b/REPOLib/Objects/Sdk/Mod.cs
@@ -30,6 +30,9 @@ public class Mod : ScriptableObject
     [SerializeField]
     private TextAsset _readme;
 
+    [SerializeField]
+    private TextAsset _changelog;
+
     public string Name => _name;
     public string Author => _author;
     public string Version => _version;
@@ -38,6 +41,7 @@ public class Mod : ScriptableObject
     public IReadOnlyList<string> Dependencies => _dependencies;
     public Sprite Icon => _icon;
     public TextAsset Readme => _readme;
+    public TextAsset Changelog => _changelog;
 
     public string FullName => $"{Author}-{Name}";
     // also known as a dependency string


### PR DESCRIPTION
Simple change that adds an optional changelog field to mod assets, for use by the SDK when packaging the mod.

See the corresponding PR on the SDK: https://github.com/ZehsTeam/REPOLib-Sdk/pull/4