### PR TITLE
FixMixerGroups added to Utilities.cs

### DIFF
--- a/REPOLib/Modules/Utilities.cs
+++ b/REPOLib/Modules/Utilities.cs
@@ -10,7 +10,7 @@ public class Utilities
     /// <summary>
     /// Fixes the mixer groups of all audio sources in the game object and its children.
     /// Assigns the audio mixer group based on the audio group found assigned in the prefab.
-    /// Best to call this method in the Awake, Start, or OnEnable method of the game object.
+    /// Best to call this method in the Start, or OnEnable method of the game object.
     /// - Vyrus
     /// </summary>
     public static void FixMixerGroups(GameObject gameObject)

--- a/REPOLib/Modules/Utilities.cs
+++ b/REPOLib/Modules/Utilities.cs
@@ -6,42 +6,39 @@ namespace REPOLib.Modules;
 
 public class Utilities
 {
-    public enum AudioMixerGroupType
-    {
-        Persistent,
-        Sound,
-        Music,
-        Microphone,
-        MicrophoneSpectate,
-        TTS,
-        TTSSpectate
-    }
-    
+
     /// <summary>
     /// Fixes the mixer groups of all audio sources in the game object and its children.
-    /// Assigns the audio mixer group based on the audio group type.
-    /// Best to call this method in the Start or OnEnable method of the game object.
+    /// Assigns the audio mixer group based on the audio group found assigned in the prefab.
+    /// Best to call this method in the Awake, Start, or OnEnable method of the game object.
     /// - Vyrus
     /// </summary>
-    public static void FixMixerGroups(GameObject gameObject, AudioMixerGroupType audioGroup)
+    public static void FixMixerGroups(GameObject gameObject)
     {
         AudioSource[] audioSources = gameObject.GetComponentsInChildren<AudioSource>();
-        
-        AudioMixerGroup targetMixerGroup = audioGroup switch
-        {
-            AudioMixerGroupType.Persistent => AudioManager.instance.PersistentSoundGroup,
-            AudioMixerGroupType.Sound => AudioManager.instance.SoundMasterGroup,
-            AudioMixerGroupType.Music => AudioManager.instance.MusicMasterGroup,
-            AudioMixerGroupType.Microphone => AudioManager.instance.MicrophoneSoundGroup,
-            AudioMixerGroupType.MicrophoneSpectate => AudioManager.instance.MicrophoneSpectateGroup,
-            AudioMixerGroupType.TTS => AudioManager.instance.TTSSoundGroup,
-            AudioMixerGroupType.TTSSpectate => AudioManager.instance.TTSSpectateGroup,
-            _ => throw new ArgumentOutOfRangeException(nameof(audioGroup), audioGroup, null)
-        };
 
         foreach (AudioSource audioSource in audioSources)
         {
-            audioSource.outputAudioMixerGroup = targetMixerGroup.audioMixer.outputAudioMixerGroup;
+            // audioSource.outputAudioMixerGroup = targetMixerGroup.audioMixer.outputAudioMixerGroup;
+
+            if (audioSource.outputAudioMixerGroup == null)
+            {
+                Logger.LogInfo($"No Audio Mixer Group is assigned to {audioSource.name}.");
+                continue;
+            }
+
+            AudioMixerGroup masterGroup = audioSource.outputAudioMixerGroup.audioMixer.name switch
+            {
+                "Master" => AudioManager.instance.MasterMixer.outputAudioMixerGroup,
+                "Sound" => AudioManager.instance.SoundMasterGroup,
+                "Music" => AudioManager.instance.MusicMasterGroup,
+                "Spectate" => AudioManager.instance.MicrophoneSpectateGroup,
+                _=> AudioManager.instance.SoundMasterGroup
+            };
+
+            Logger.LogInfo($"Audio Mixer Group is now assigned to {masterGroup.name}. Audio Source: {audioSource.name}");
+            audioSource.outputAudioMixerGroup = masterGroup;
+            
         }
     }
 }

--- a/REPOLib/Modules/Utilities.cs
+++ b/REPOLib/Modules/Utilities.cs
@@ -1,0 +1,47 @@
+using System;
+using UnityEngine;
+using UnityEngine.Audio;
+
+namespace REPOLib.Modules;
+
+public class Utilities
+{
+    public enum AudioMixerGroupType
+    {
+        Persistent,
+        Sound,
+        Music,
+        Microphone,
+        MicrophoneSpectate,
+        TTS,
+        TTSSpectate
+    }
+    
+    /// <summary>
+    /// Fixes the mixer groups of all audio sources in the game object and its children.
+    /// Assigns the audio mixer group based on the audio group type.
+    /// Best to call this method in the Start or OnEnable method of the game object.
+    /// - Vyrus
+    /// </summary>
+    public static void FixMixerGroups(GameObject gameObject, AudioMixerGroupType audioGroup)
+    {
+        AudioSource[] audioSources = gameObject.GetComponentsInChildren<AudioSource>();
+        
+        AudioMixerGroup targetMixerGroup = audioGroup switch
+        {
+            AudioMixerGroupType.Persistent => AudioManager.instance.PersistentSoundGroup,
+            AudioMixerGroupType.Sound => AudioManager.instance.SoundMasterGroup,
+            AudioMixerGroupType.Music => AudioManager.instance.MusicMasterGroup,
+            AudioMixerGroupType.Microphone => AudioManager.instance.MicrophoneSoundGroup,
+            AudioMixerGroupType.MicrophoneSpectate => AudioManager.instance.MicrophoneSpectateGroup,
+            AudioMixerGroupType.TTS => AudioManager.instance.TTSSoundGroup,
+            AudioMixerGroupType.TTSSpectate => AudioManager.instance.TTSSpectateGroup,
+            _ => throw new ArgumentOutOfRangeException(nameof(audioGroup), audioGroup, null)
+        };
+
+        foreach (AudioSource audioSource in audioSources)
+        {
+            audioSource.outputAudioMixerGroup = targetMixerGroup.audioMixer.outputAudioMixerGroup;
+        }
+    }
+}


### PR DESCRIPTION
Adds a Utility function to fix audio mixer groups on GameObjects, allowing custom audio to be possible.