### PR TITLE
Remove changelog field

### DIFF
--- a/REPOLib/Objects/Sdk/Mod.cs
+++ b/REPOLib/Objects/Sdk/Mod.cs
@@ -30,9 +30,6 @@ public class Mod : ScriptableObject
     [SerializeField]
     private TextAsset _readme;
 
-    [SerializeField]
-    private TextAsset _changelog;
-
     public string Name => _name;
     public string Author => _author;
     public string Version => _version;
@@ -40,8 +37,7 @@ public class Mod : ScriptableObject
     public string WebsiteUrl => _websiteUrl;
     public IReadOnlyList<string> Dependencies => _dependencies;
     public Sprite Icon => _icon;
-    public TextAsset Readme => _readme;
-    public TextAsset Changelog => _changelog;
+    public TextAsset Readme => _readme; 
 
     public string FullName => $"{Author}-{Name}";
     // also known as a dependency string


### PR DESCRIPTION
Paired with https://github.com/ZehsTeam/REPOLib-Sdk/pull/7 to remove the now redundant changelog field in `Mod`.