### PR TITLE
Add partial name matching for valuable search

### DIFF
--- a/REPOLib/Commands/SpawnItemCommand.cs
+++ b/REPOLib/Commands/SpawnItemCommand.cs
@@ -97,8 +97,8 @@ public static class SpawnItemCommand
         Item[] items = StatsManager.instance.itemDictionary.Values.ToArray();
 
         item = items.FirstOrDefault(x => 
-            x.itemAssetName.Equals(name, StringComparison.OrdinalIgnoreCase) ||
-            x.itemName.Equals(name, StringComparison.OrdinalIgnoreCase));
+            x.itemAssetName.Contains(name, StringComparison.OrdinalIgnoreCase) ||
+            x.itemName.Contains(name, StringComparison.OrdinalIgnoreCase));
 
         return item != null;
     }

--- a/REPOLib/Commands/SpawnValuableCommand.cs
+++ b/REPOLib/Commands/SpawnValuableCommand.cs
@@ -3,6 +3,7 @@ using REPOLib.Extensions;
 using REPOLib.Modules;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace REPOLib.Commands;
@@ -136,14 +137,16 @@ public static class SpawnValuableCommand
 
     private static bool TryGetValuableByName(string name, out GameObject prefab)
     {
-        if (valuablePrefabs.TryGetValue(name.ToLower(), out prefab))
-        {
-            return true;
-        }
+        prefab = null;
+        string lowerName = name.ToLower();
 
-        if (valuablePrefabs.TryGetValue("valuable " + name.ToLower(), out prefab))
+        foreach (var key in valuablePrefabs.Keys)
         {
-            return true;
+            if (key.ToLower().Contains(lowerName))
+            {
+                prefab = valuablePrefabs[key];
+                return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
Replaced exact match checks with substring-based searches to improve valuable and item lookup. This allows users to find items using partial names instead of full names.