### PR TITLE
MSBuild: Allow setting BepInExPluginsFolder directly, and warn if it's not set

### DIFF
--- a/REPOLib/REPOLib.csproj
+++ b/REPOLib/REPOLib.csproj
@@ -82,11 +82,11 @@
   </PropertyGroup>
   
   <!-- Copy DLL to Gale Zehs-REPOLib plugin folder -->
-  <Target Name="CopyToGalePluginFolder" AfterTargets="PostBuildEvent" Condition="Exists('$(BepInExPluginsFolder)')">
+  <Target Name="CopyToPluginsFolder" AfterTargets="PostBuildEvent" Condition="Exists('$(BepInExPluginsFolder)')">
     <Copy DestinationFolder="$(REPOLibPluginFolder)" OverwriteReadOnlyFiles="true" SkipUnchangedFiles="true" SourceFiles="$(TargetPath)" />
   </Target>
 
-  <Target Name="ValidateCopiedPlugin" AfterTargets="CopyToGalePluginFolder" Condition="!Exists('$(BepInExPluginsFolder)') And $(CI) != 'true'" >
+  <Target Name="ValidateCopiedPlugin" AfterTargets="CopyToPluginsFolder" Condition="!Exists('$(BepInExPluginsFolder)') And $(CI) != 'true'" >
     <Warning Text="Couldn't copy build target to '$(BepInExPluginsFolder)' because the path does not exist. Configure the path in your REPOLib.csproj.user file."/>
   </Target>
 </Project>

--- a/REPOLib/REPOLib.csproj
+++ b/REPOLib/REPOLib.csproj
@@ -73,19 +73,20 @@
   <!-- Default values in case the .csproj.user file doesn't exist -->
   <PropertyGroup>
     <GaleProfile Condition="'$(GaleProfile)' == ''">Mod Development</GaleProfile>
-    <GaleDataFolder Condition="'$(GaleDataFolder)' == ''">$(AppData)\com.kesomannen.gale/</GaleDataFolder>
+    <GaleDataFolder Condition="'$(GaleDataFolder)' == ''">$(AppData)\com.kesomannen.gale</GaleDataFolder>
   </PropertyGroup>
   
   <PropertyGroup>
-    <!-- Gale plugins folder -->
-    <GalePluginsFolder>$(GaleDataFolder)\repo\profiles\$(GaleProfile)\BepInEx\plugins</GalePluginsFolder>
-    
-    <!-- Gale plugin folder -->
-    <GalePluginFolder>$(GalePluginsFolder)\Zehs-$(MSBuildProjectName)</GalePluginFolder>
+    <BepInExPluginsFolder Condition="'$(BepInExPluginsFolder)' == ''">$(GaleDataFolder)\repo\profiles\$(GaleProfile)\BepInEx\plugins\</BepInExPluginsFolder>
+    <REPOLibPluginFolder Condition="'$(REPOLibPluginFolder)' == ''">$(BepInExPluginsFolder)Zehs-$(MSBuildProjectName)\</REPOLibPluginFolder>
   </PropertyGroup>
   
   <!-- Copy DLL to Gale Zehs-REPOLib plugin folder -->
-  <Target Name="CopyToGalePluginFolder" AfterTargets="PostBuildEvent">
-    <Copy DestinationFolder="$(GalePluginFolder)" OverwriteReadOnlyFiles="true" SkipUnchangedFiles="true" SourceFiles="$(TargetPath)" />
+  <Target Name="CopyToGalePluginFolder" AfterTargets="PostBuildEvent" Condition="Exists('$(BepInExPluginsFolder)')">
+    <Copy DestinationFolder="$(REPOLibPluginFolder)" OverwriteReadOnlyFiles="true" SkipUnchangedFiles="true" SourceFiles="$(TargetPath)" />
+  </Target>
+
+  <Target Name="ValidateCopiedPlugin" AfterTargets="CopyToGalePluginFolder" Condition="!Exists('$(BepInExPluginsFolder)') And $(CI) != 'true'" >
+    <Warning Text="Couldn't copy build target to '$(BepInExPluginsFolder)' because the path does not exist. Configure the path in your REPOLib.csproj.user file."/>
   </Target>
 </Project>

--- a/REPOLib/REPOLib.csproj.user.example
+++ b/REPOLib/REPOLib.csproj.user.example
@@ -6,5 +6,8 @@
         
         <!-- Gale data folder -->
         <GaleDataFolder>$(AppData)\com.kesomannen.gale</GaleDataFolder>
+
+        <!-- If not using Gale, set the BepInExPluginsFolder path directly, otherwise leave empty -->
+        <BepInExPluginsFolder></BepInExPluginsFolder>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Makes building REPOLib more friendly to developers who are not using gale.
Warns if `BepInExPluginsFolder` is not found. Doesn't warn if CI is true (for example when running in GitHub Actions)