### PR TITLE
Add GitHub Actions workflows for building and publishing to Thunderstore and NuGet

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "tcli": {
+      "version": "0.2.4",
+      "commands": [
+        "tcli"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: tree:0
 
       - name: Setup Dotnet
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  # Trigger the workflow on pushes to only the 'main' branch (this avoids duplicate checks being run e.g., for dependabot pull requests)
+  push:
+    branches: [ main ]
+  # Trigger the workflow on any pull request
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.x"
+
+      - name: Restore
+        run: |
+          dotnet restore --locked-mode
+          dotnet tool restore
+
+      - name: Build
+        run: |
+          dotnet build -c Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish
+
+on:
+  release:
+    types: [prereleased, released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.x"
+
+      - name: Restore
+        run: |
+          dotnet restore --locked-mode
+          dotnet tool restore
+
+      - name: Build
+        run: |
+          dotnet build -c Release
+
+      - name: Pack and Publish to Thunderstore
+        env:
+          TCLI_AUTH_TOKEN: ${{ secrets.TCLI_AUTH_TOKEN }}
+        run: |
+          dotnet pack -c Release --no-build -target:PublishThunderstore
+
+      - name: Publish to NuGet.org
+        run: |
+          dotnet nuget push ./artifacts/package/*/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+          filter: tree:0
 
       - name: Setup Dotnet
         uses: actions/setup-dotnet@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,88 @@
+# v1.5.0
+
+- Added partial name matching to all spawn commands. (#17)
+- Added a new developer mode command `Spawn Enemy`.
+  - Usage: `/spawnenemy <name>` (`/se` for short)
+  - You must enable `DeveloperMode` mode in the config settings to use developer mode commands.
+  - Note: developer mode commands are host-only!
+- Added methods/properties to the Valuables module.
+  - `SpawnValuable` - Spawn a valuable.
+  - `AllValuables` and `GetValuables` - Returns a list of all the valuables registered in the game. (Vanilla and Modded)
+  - `GetValuableByName` and `TryGetValuableByName` - Returns a valuable prefab that equals the name.
+  - `GetValuableThatContainsName` and `TryGetValuableThatContainsName` - Returns a valuable prefab that contains the name.
+- Added methods/properties to the Items module.
+  - `SpawnItem` - Spawn an item.
+  - `AllItems` and `GetItems` - Returns a list of all the items registered in the game. (Vanilla and Modded)
+  - `GetItemByName` and `TryGetItemByName` - Returns an item that equals the name.
+  - `GetItemThatContainsName` and `TryGetItemThatContainsName` - Returns an item that contains the name.
+- Added methods/properties to the Enemies module.
+  - `SpawnEnemy` - Spawn an enemy.
+  - `AllEnemies` and `GetEnemies` - Returns a list of all the enemies registered in the game. (Vanilla and Modded)
+  - `GetEnemyByName` and `TryGetEnemyByName` - Returns an EnemySetup that equals the name.
+  - `GetEnemyThatContainsName` and `TryGetEnemyThatContainsName` - Returns an EnemySetup that contains the name.
+- Added a method to the NetworkPrefabs module.
+  - `SpawnNetworkPrefab` - Spawn a network prefab by providing a prefab ID.
+    - This method works in both multiplayer and singleplayer.
+    - Note: this will only spawn registered network prefabs.
+- You can now toggle developer mode using the REPOConfig mod.
+- You can now register enemy groups if you have already registered that enemy previously.
+
+## v1.4.2
+
+- Removed changelog field from the `Mod` asset. (#14)
+
+### REPOLib-Sdk v1.2.0
+
+- Added an `Extra Files` field to the `Mod` asset. (REPOLib-Sdk#7)
+  - You can put your changelog file here.
+
+## v1.4.1
+
+- Added [`RaiseMasterClient`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Modules/NetworkedEvent.cs#L32) to [`REPOLib.Modules.NetworkingEvents`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Modules/NetworkedEvent.cs) class.
+- Added [`RaiseEvent`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Modules/NetworkedEvent.cs#L128) method to [`REPOLib.Modules.NetworkedEvent`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Modules/NetworkedEvent.cs#L101) class.
+  - This method works to call in singleplayer.
+
+## v1.4.0
+
+- Added REPOLib as default dependency to the `Mod` asset. (#11)
+- Added [`REPOLib.Modules.Utilities`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Modules/Utilities.cs) class that contains a function [`public static void FixAudioMixerGroups(GameObject prefab);`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Modules/Utilities.cs#L28) to fix the audio mixer groups on a prefab and their children. (#10)
+- Registering features (Valuables, Items, Enemies, etc...) will now automatically fix their prefabs audio mixer groups.
+- Added [`REPOLib.Modules.NetworkedEvent`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Modules/NetworkedEvent.cs#L96) class to easily manage your event codes when using [`PhotonNetwork.RaiseEvent();`](https://doc.photonengine.com/pun/current/gameplay/rpcsandraiseevent) (#12)
+
+## v1.3.1
+
+- Added changelog field to the `Mod` asset. (#9)
+
+## v1.3.0
+
+- Added more validation when registering features to prevent conflicts and errors.
+- Added support for registering custom chat /commands. (#5)
+  - Added some built-in developer mode commands: `/spawnvaluable <name>`, `/spawnitem <name>` (`/sv` and `/si` for short)
+    - You must enable `DeveloperMode` mode in the config settings to use developer mode commands.
+    - Note: developer mode commands are host-only!
+
+## v1.2.0
+
+- Added support for registering items.
+- Added support for registering enemies. (#2)
+- Added support for registering features without code using the [REPOLib-Sdk](https://github.com/ZehsTeam/REPOLib-Sdk). (#3)
+- Features now register network prefabs to have their prefabId match the Resources folder structure.
+- You can no longer manually pass in a prefabId when registering a valuable.
+
+## v1.1.0
+
+- You can now register valuables to specific levels. (#1)
+  - Valuables Presets: `Valuables - Generic`, `Valuables - Wizard`, `Valuables - Manor`, `Valuables - Arctic`
+
+## v1.0.2
+
+- Small improvement to [`NetworkPrefabs.cs`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Modules/NetworkPrefabs.cs), [`Valuables.cs`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Modules/Valuables.cs), [`CustomPrefabPool.cs`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Objects/CustomPrefabPool.cs), [`LevelValuablesExtension.cs`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Extensions/LevelValuablesExtension.cs), and other.
+- Added `public static IReadOnlyList<GameObject> RegisteredValuables { get; }` to [`Valuables.cs`](https://github.com/ZehsTeam/REPOLib/blob/main/REPOLib/Modules/Valuables.cs#L11)
+
+## v1.0.1
+
+- Updated mod icon.
+
+## v1.0.0
+
+- Initial release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+## Making Thunderstore packages locally
+
+Build the project while manually specifying the `PackThunderstore` target: `dotnet build -target:PackThunderstore` (run on the commandline).  
+For trying out the automatic publishing of the Thunderstore package, use `dotnet build -target:PublishThunderstore`. This won't actually publish the package unless if you have the `TCLI_AUTH_TOKEN` environment variable set to the valid value for an API token for the Thunderstore team.
+
+## For Maintainers
+
+### Publishing New Releases
+
+> [!NOTE]  
+> This project uses [MinVer](<https://github.com/adamralph/minver>) for versioning via git tags.
+
+New releases can be published by creating a new GitHub release, and setting the tag to a valid SemVer version, prefixed with `v`. GitHub Actions will then build the new version and automatically attach files to the new release, so don't add any files to the release manually. The Thunderstore package and NuGet package also get published.
+
+- Examples: `v1.0.0`, `v1.1.1`.
+- To release a prerelease version, use the `dev`-prefix: `v1.1.1-dev`, `v1.1.1-dev.0`. Don't release a prerelease version though, since those aren't supported on Thunderstore and we haven't setup a separate Thunderstore package for a beta version.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,4 +4,16 @@
     <UseArtifactsOutput>true</UseArtifactsOutput>
   </PropertyGroup>
 
+  <!-- MinVer -->
+  <PropertyGroup>
+      <MinVerDefaultPreReleaseIdentifiers>dev</MinVerDefaultPreReleaseIdentifiers>
+      <MinVerTagPrefix>v</MinVerTagPrefix>
+  </PropertyGroup>
+  <ItemGroup>
+      <PackageReference Include="MinVer" Version="4.3.0">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+  </PropertyGroup>
+
+</Project>

--- a/REPOLib/REPOLib.csproj
+++ b/REPOLib/REPOLib.csproj
@@ -82,11 +82,11 @@
   </PropertyGroup>
   
   <!-- Copy DLL to Gale Zehs-REPOLib plugin folder -->
-  <Target Name="CopyToGalePluginFolder" AfterTargets="PostBuildEvent" Condition="Exists('$(BepInExPluginsFolder)')">
+  <Target Name="CopyToPluginsFolder" AfterTargets="PostBuildEvent" Condition="Exists('$(BepInExPluginsFolder)')">
     <Copy DestinationFolder="$(REPOLibPluginFolder)" OverwriteReadOnlyFiles="true" SkipUnchangedFiles="true" SourceFiles="$(TargetPath)" />
   </Target>
 
-  <Target Name="ValidateCopiedPlugin" AfterTargets="CopyToGalePluginFolder" Condition="!Exists('$(BepInExPluginsFolder)') And $(CI) != 'true'" >
+  <Target Name="ValidateCopiedPlugin" AfterTargets="CopyToPluginsFolder" Condition="!Exists('$(BepInExPluginsFolder)') And $(CI) != 'true'" >
     <Warning Text="Couldn't copy build target to '$(BepInExPluginsFolder)' because the path does not exist. Configure the path in your REPOLib.csproj.user file."/>
   </Target>
 </Project>

--- a/REPOLib/REPOLib.csproj
+++ b/REPOLib/REPOLib.csproj
@@ -7,7 +7,7 @@
     
     <AssemblyName>$(MSBuildProjectName)</AssemblyName> <!-- PLUGIN_GUID -->
     <Product>$(MSBuildProjectName)</Product>           <!-- PLUGIN_NAME -->
-    <Version>1.5.0</Version>                           <!-- PLUGIN_VERSION -->
+    <!-- <Version/> is handled by MinVer with Git tags -->
     <Authors>Zehs</Authors>
     <Description>Library for adding content to R.E.P.O.</Description>
     <PackageTags>R.E.P.O., unity, bepinex, photon-pun, modding</PackageTags>
@@ -38,6 +38,14 @@
       https://nuget.samboy.dev/v3/index.json;
     </RestoreAdditionalProjectSources>
   </PropertyGroup>
+  
+  <!-- Target 'AddGeneratedFile' is from BepInEx.PluginInfoProps -->
+  <Target Name="SetPluginVersion" BeforeTargets="AddGeneratedFile" DependsOnTargets="MinVer">
+      <PropertyGroup>
+          <PlainVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</PlainVersion>
+          <BepInExPluginVersion>$(PlainVersion)</BepInExPluginVersion>
+      </PropertyGroup>
+  </Target>
   
   <Target Name="ClearReferenceCopyLocalPaths" AfterTargets="ResolveAssemblyReferences">
     <ItemGroup>
@@ -85,13 +93,17 @@
   </Target>
 
   <!-- Call with `dotnet build -target:PackThunderstore` -->
-  <Target Name="PackThunderstore" DependsOnTargets="PostBuildEvent">
+  <Target Name="PackThunderstore" DependsOnTargets="PostBuildEvent;SetPluginVersion">
     <Exec Command="dotnet tool restore" />
-    <Exec Command="dotnet tcli build --config-path &quot;$(ProjectDir)Thunderstore/thunderstore.toml&quot; --package-version $(Version)" />
+    <Exec Command="dotnet tcli build --config-path &quot;$(ProjectDir)Thunderstore/thunderstore.toml&quot; --package-version $(PlainVersion)" />
+    <ItemGroup>
+      <FilesToRename Include="$(ProjectDir)dist/*-$(PlainVersion).zip" />
+    </ItemGroup>
+    <Move SourceFiles="@(FilesToRename)" DestinationFiles="@(FilesToRename -&gt; Replace($(PlainVersion), $(MinVerVersion)))" />
   </Target>
 
   <!-- This is manually called by the github actions publish workflow -->
   <Target Name="PublishThunderstore" DependsOnTargets="PackThunderstore">
-    <Exec Command="dotnet tcli publish --config-path &quot;$(ProjectDir)Thunderstore/thunderstore.toml&quot; --file &quot;$(SolutionDir)artifacts/thunderstore/Zehs-REPOLib-$(Version).zip&quot;" />
+    <Exec Command="dotnet tcli publish --config-path &quot;$(ProjectDir)Thunderstore/thunderstore.toml&quot; --file &quot;$(SolutionDir)artifacts/thunderstore/Zehs-REPOLib-$(MinVerVersion).zip&quot;" />
   </Target>
 </Project>

--- a/REPOLib/REPOLib.csproj
+++ b/REPOLib/REPOLib.csproj
@@ -24,16 +24,13 @@
     <PackageId>Zehs.$(AssemblyName)</PackageId>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageOutputPath>$(OutputPath)</PackageOutputPath>
-    
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
+    <!-- Trim the project path in debug symbols -->
+    <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./</PathMap>
     
     <RestoreAdditionalProjectSources>
       https://api.nuget.org/v3/index.json;
@@ -60,15 +57,12 @@
   <ItemGroup>
     <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.2" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
-    <PackageReference Include="BepInEx.Core" Version="5.*" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
+    <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.21" IncludeAssets="compile" PrivateAssets="all" />
-    <PackageReference Include="R.E.P.O.GameLibs.Steam" Version="0.1.2-ngd.0" />
+    <PackageReference Include="R.E.P.O.GameLibs.Steam" Version="0.1.2-ngd.0" PrivateAssets="all"/>
   </ItemGroup>
-  
-  <!-- Import settings from .csproj.user file -->
-  <Import Project="$(MSBuildProjectFile).user" Condition="Exists('$(MSBuildProjectFile).user')" />
   
   <!-- Default values in case the .csproj.user file doesn't exist -->
   <PropertyGroup>
@@ -88,5 +82,16 @@
 
   <Target Name="ValidateCopiedPlugin" AfterTargets="CopyToPluginsFolder" Condition="!Exists('$(BepInExPluginsFolder)') And $(CI) != 'true'" >
     <Warning Text="Couldn't copy build target to '$(BepInExPluginsFolder)' because the path does not exist. Configure the path in your REPOLib.csproj.user file."/>
+  </Target>
+
+  <!-- Call with `dotnet build -target:PackThunderstore` -->
+  <Target Name="PackThunderstore" DependsOnTargets="PostBuildEvent">
+    <Exec Command="dotnet tool restore" />
+    <Exec Command="dotnet tcli build --config-path &quot;$(ProjectDir)Thunderstore/thunderstore.toml&quot; --package-version $(Version)" />
+  </Target>
+
+  <!-- This is manually called by the github actions publish workflow -->
+  <Target Name="PublishThunderstore" DependsOnTargets="PackThunderstore">
+    <Exec Command="dotnet tcli publish --config-path &quot;$(ProjectDir)Thunderstore/thunderstore.toml&quot; --file &quot;$(SolutionDir)artifacts/thunderstore/Zehs-REPOLib-$(Version).zip&quot;" />
   </Target>
 </Project>

--- a/REPOLib/REPOLib.csproj
+++ b/REPOLib/REPOLib.csproj
@@ -73,19 +73,20 @@
   <!-- Default values in case the .csproj.user file doesn't exist -->
   <PropertyGroup>
     <GaleProfile Condition="'$(GaleProfile)' == ''">Mod Development</GaleProfile>
-    <GaleDataFolder Condition="'$(GaleDataFolder)' == ''">$(AppData)\com.kesomannen.gale/</GaleDataFolder>
+    <GaleDataFolder Condition="'$(GaleDataFolder)' == ''">$(AppData)\com.kesomannen.gale</GaleDataFolder>
   </PropertyGroup>
   
   <PropertyGroup>
-    <!-- Gale plugins folder -->
-    <GalePluginsFolder>$(GaleDataFolder)\repo\profiles\$(GaleProfile)\BepInEx\plugins</GalePluginsFolder>
-    
-    <!-- Gale plugin folder -->
-    <GalePluginFolder>$(GalePluginsFolder)\Zehs-$(MSBuildProjectName)</GalePluginFolder>
+    <BepInExPluginsFolder Condition="'$(BepInExPluginsFolder)' == ''">$(GaleDataFolder)\repo\profiles\$(GaleProfile)\BepInEx\plugins\</BepInExPluginsFolder>
+    <REPOLibPluginFolder Condition="'$(REPOLibPluginFolder)' == ''">$(BepInExPluginsFolder)Zehs-$(MSBuildProjectName)\</REPOLibPluginFolder>
   </PropertyGroup>
   
   <!-- Copy DLL to Gale Zehs-REPOLib plugin folder -->
-  <Target Name="CopyToGalePluginFolder" AfterTargets="PostBuildEvent">
-    <Copy DestinationFolder="$(GalePluginFolder)" OverwriteReadOnlyFiles="true" SkipUnchangedFiles="true" SourceFiles="$(TargetPath)" />
+  <Target Name="CopyToGalePluginFolder" AfterTargets="PostBuildEvent" Condition="Exists('$(BepInExPluginsFolder)')">
+    <Copy DestinationFolder="$(REPOLibPluginFolder)" OverwriteReadOnlyFiles="true" SkipUnchangedFiles="true" SourceFiles="$(TargetPath)" />
+  </Target>
+
+  <Target Name="ValidateCopiedPlugin" AfterTargets="CopyToGalePluginFolder" Condition="!Exists('$(BepInExPluginsFolder)') And $(CI) != 'true'" >
+    <Warning Text="Couldn't copy build target to '$(BepInExPluginsFolder)' because the path does not exist. Configure the path in your REPOLib.csproj.user file."/>
   </Target>
 </Project>

--- a/REPOLib/REPOLib.csproj.user.example
+++ b/REPOLib/REPOLib.csproj.user.example
@@ -6,5 +6,8 @@
         
         <!-- Gale data folder -->
         <GaleDataFolder>$(AppData)\com.kesomannen.gale</GaleDataFolder>
+
+        <!-- If not using Gale, set the BepInExPluginsFolder path directly, otherwise leave empty -->
+        <BepInExPluginsFolder></BepInExPluginsFolder>
     </PropertyGroup>
 </Project>

--- a/REPOLib/Thunderstore/thunderstore.toml
+++ b/REPOLib/Thunderstore/thunderstore.toml
@@ -1,0 +1,36 @@
+[config]
+schemaVersion = "0.0.1"
+
+[general]
+repository = "https://thunderstore.io"
+
+[package]
+namespace = "Zehs"
+name = "REPOLib"
+description = "Library for adding content to R.E.P.O."
+websiteUrl = "https://github.com/ZehsTeam/REPOLib"
+containsNsfwContent = false
+[package.dependencies]
+BepInEx-BepInExPack = "5.4.2100"
+
+[build]
+icon = "../../icon.png"
+readme = "../../README.md"
+outdir = "../../artifacts/thunderstore/"
+
+[[build.copy]]
+source = "../../artifacts/bin/REPOLib/release/REPOLib.dll"
+target = "plugins/"
+
+[[build.copy]]
+source = "../../CHANGELOG.md"
+target = "/"
+
+[[build.copy]]
+source = "../../LICENSE.txt"
+target = "/"
+
+[publish]
+communities = [ "repo", ]
+[publish.categories]
+repo = [ "mods", "tools", "libraries", ]


### PR DESCRIPTION
> [!NOTE]
> This PR depends on #27 

- Added CHANGELOG.md
- Added TCLI to dotnet tools for building and publishing to thunderstore
  - Added its thunderstore.toml configuration file which defines what goes in the Thunderstore pacakge and where it's published
- Fixed some NuGet package configuration
  - Set development only dependencies to `PrivateAssets="all"` so users of the REPOLib nuget package don't also have to reference those dependencies.
  - Removed symbolic nuget package generation since debug symbols are already embedded in the dll
  - Don't build nuget pacakge on every build (use `dotnet pack` if you want to build a nuget package manually)
- Added GitHub Actions workflows for:
  - Building on each commit on PRs, Building on each commit on main branch (validates that the package builds properly)
  - Publishing  to Thunderstore and NuGet on GitHub releases and prereleases
- Added MinVer for versioning via Git tags (removes the need to manually change the version in the csproj, and then having to write it also in the release tags)
- Added `CONTRIBUTING.md` file which explains how to build packages and publish new releases
- Stripped the full build path from debug symbols because it's useless and makes it cleaner. For example this:
  - `REPOLib.Objects.CustomPrefabPool.RegisterPrefab (System.String prefabId, UnityEngine.GameObject prefab) (at D:/Documents/Visual Studio Projects/REPO Mods/REPOLib/REPOLib/Objects/CustomPrefabPool.cs:83)` would become:
  - `REPOLib.Objects.CustomPrefabPool.RegisterPrefab (System.String prefabId, UnityEngine.GameObject prefab) (at ./Objects/CustomPrefabPool.cs:83)`
- Use Artifacts output so `bin/`, `obj/`, `packages/` (nuget pacakges), `thunderstore/` (this one is where I made TCLI build ts packages) are all nicely under the `/artifacts/` directory at the root of the repo. It's also useful if more project files are added to the REPOLib project.
- Removed `<Import Project="$(MSBuildProjectFile).user" Condition="Exists('$(MSBuildProjectFile).user')" />` from the csproj since this is already done automatically and msbuild was complaining about it.

## Required Before Publishing to Thunderstore and NuGet works from GitHub Actions
Before you follow the link, note the *(Name it as: `foo`)* comments I wrote on the steps. Use those names for the secrets instead of what's said in the link.
See <https://github.com/ContentWarningCommunity/Content-Warning-Mod-Templates/blob/main/content/Github/Github-Workflow-README.md#final-setup>
Complete the following Steps:
- Setup GitHub Repo
  - Enable Write Access for Actions
  - Get Thunderstore API Token
    - This is the part where you might want to instead create a new Thunderstore team to ensure the key is only valid for that new team.
  -  Add Thunderstore API Token as a GitHub Repo Secret (Name it as: `TCLI_AUTH_TOKEN`)
  - Get NuGet API Key
  - Add NuGet API Key as a GitHub Repo Secret (Name it as: `NUGET_API_KEY`)
  
  Note about the *Change Icon* step: I don't know if it's necessary, but if the publish workflow fails, we can simply just fix it then.