### PR TITLE
Update CommandManager.cs

### DIFF
--- a/REPOLib/Commands/CommandManager.cs
+++ b/REPOLib/Commands/CommandManager.cs
@@ -22,7 +22,7 @@ internal static class CommandManager
 
         CommandInitializerMethods = AccessTools.AllTypes()
             .SelectMany(type => type.SafeGetMethods())
-            .Where(method => method?.GetCustomAttribute<CommandInitializerAttribute>() != null)
+            .Where(method => method.GetCustomAttribute<CommandInitializerAttribute>() != null)
             .ToList();
 
         foreach (var command in CommandInitializerMethods)
@@ -61,7 +61,7 @@ internal static class CommandManager
     {
         _commandExecutionMethodCache = AccessTools.AllTypes()
             .SelectMany(type => type.SafeGetMethods())
-            .Where(method => method?.GetCustomAttribute<CommandExecutionAttribute>() != null)
+            .Where(method => method.GetCustomAttribute<CommandExecutionAttribute>() != null)
             .ToList();
 
         foreach (var method in _commandExecutionMethodCache)

--- a/REPOLib/Commands/CommandManager.cs
+++ b/REPOLib/Commands/CommandManager.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using HarmonyLib;
 using REPOLib.Extensions;
 
 namespace REPOLib.Commands;
@@ -19,8 +20,7 @@ internal static class CommandManager
     {
         Logger.LogInfo($"CommandManager initializing.", extended: true);
 
-        CommandInitializerMethods = AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(HarmonyLib.AccessTools.GetTypesFromAssembly)
+        CommandInitializerMethods = AccessTools.AllTypes()
             .SelectMany(type => type.SafeGetMethods())
             .Where(method => method?.GetCustomAttribute<CommandInitializerAttribute>() != null)
             .ToList();
@@ -59,8 +59,7 @@ internal static class CommandManager
 
     public static void FindAllCommandMethods()
     {
-        _commandExecutionMethodCache = AppDomain.CurrentDomain.GetAssemblies()
-            .SelectMany(HarmonyLib.AccessTools.GetTypesFromAssembly)
+        _commandExecutionMethodCache = AccessTools.AllTypes()
             .SelectMany(type => type.SafeGetMethods())
             .Where(method => method?.GetCustomAttribute<CommandExecutionAttribute>() != null)
             .ToList();
@@ -106,7 +105,7 @@ internal static class CommandManager
         {
             var execAttribute = method.GetCustomAttribute<CommandExecutionAttribute>();
 
-            var bepinPluginClass = HarmonyLib.AccessTools.GetTypesFromAssembly(method.Module.Assembly)
+            var bepinPluginClass = AccessTools.GetTypesFromAssembly(method.Module.Assembly)
                 .Where(type => type.GetCustomAttribute<BepInPlugin>() != null)
                 .ToList()[0].GetCustomAttribute<BepInPlugin>();
             string sourceModGUID = bepinPluginClass?.GUID ?? "Unknown";

--- a/REPOLib/Extensions/TypeExtensions.cs
+++ b/REPOLib/Extensions/TypeExtensions.cs
@@ -2,22 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
-#nullable enable
-
 namespace REPOLib.Extensions;
 
 internal static class TypeExtensions
 {
-    public static IEnumerable<MethodInfo?> SafeGetMethods(this Type type)
+    public static IEnumerable<MethodInfo> SafeGetMethods(this Type type)
     {
         try
         {
             return type.GetMethods();
         }
-        catch /*(Exception ex)*/
+        catch (Exception ex)
         {
-            //Logger.LogWarning($"Error retrieving methods for type {type.FullName}: {ex.Message}");
-            return null;
+            // Logger.LogWarning($"Error retrieving methods for type {type.FullName}: {ex.Message}");
+            return Array.Empty<MethodInfo>();
         }
     }
 }

--- a/REPOLib/Extensions/TypeExtensions.cs
+++ b/REPOLib/Extensions/TypeExtensions.cs
@@ -10,13 +10,11 @@ internal static class TypeExtensions
     {
         try
         {
-            // Return methods safely
             return type.GetMethods();
         }
         catch (Exception ex)
         {
-            // Log and return null if there's an error
-            // Console.WriteLine($"Error retrieving methods for type {type.FullName}: {ex.Message}");
+            // Log($"Error retrieving methods for type {type.FullName}: {ex.Message}");
             return null;
         }
     }

--- a/REPOLib/Extensions/TypeExtensions.cs
+++ b/REPOLib/Extensions/TypeExtensions.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
+#nullable enable
+
 namespace REPOLib.Extensions;
 
 internal static class TypeExtensions

--- a/REPOLib/Extensions/TypeExtensions.cs
+++ b/REPOLib/Extensions/TypeExtensions.cs
@@ -12,7 +12,7 @@ internal static class TypeExtensions
         {
             return type.GetMethods();
         }
-        catch (Exception ex)
+        catch /*(Exception ex)*/
         {
             // Logger.LogWarning($"Error retrieving methods for type {type.FullName}: {ex.Message}");
             return Array.Empty<MethodInfo>();


### PR DESCRIPTION
I should've proposed this in my earlier pull request (#26). Only if I took the time to read the Harmony docs sooner 😔

https://github.com/pardeike/Harmony/blob/master/Harmony/Tools/AccessTools.cs/#L83-L86
```
/// <summary>Enumerates all successfully loaded types in the current app domain, excluding visual studio assemblies</summary>
/// <returns>An enumeration of all <see cref="Type"/> in all assemblies, excluding visual studio assemblies</returns>
///
public static IEnumerable<Type> AllTypes() => AllAssemblies().SelectMany(GetTypesFromAssembly);
```