### PR TITLE
Add support for custom levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - **Registering valuables.**
 - **Registering items.**
 - **Registering enemies.**
+- **Registering levels.**
 - ResourcesHelper to help get network prefab IDs.
 - Method to spawn network prefabs. (Which works in both multiplayer and singleplayer)
 - Methods to get valuables and spawn valuables.
@@ -171,6 +172,32 @@ public class YourMod : BaseUnityPlugin
     }
 }
 ```
+</details>
+
+
+<details><summary>Levels</summary><br>
+
+Registering a level.
+```cs
+[BepInPlugin("You.YourMod", "YourMod", "1.0.0")]
+[BepInDependency(REPOLib.MyPluginInfo.PLUGIN_GUID, BepInDependency.DependencyFlags.HardDependency)]
+public class YourMod : BaseUnityPlugin
+{
+    // ...
+
+    private void Awake()
+    {
+        // ...
+
+        AssetBundle assetBundle = AssetBundle.LoadFromFile("your_assetbundle_file_path");
+        Level level = assetBundle.LoadAsset<Level>("your_level");
+
+        // Register a level.
+        REPOLib.Modules.Levels.RegisterLevel(level);
+    }
+}
+```
+
 </details>
 
 <details><summary>Chat commands</summary><br>

--- a/REPOLib/Modules/Levels.cs
+++ b/REPOLib/Modules/Levels.cs
@@ -55,7 +55,7 @@ public static class Levels
                     // Check if the mod author accidentally included a vanilla preset (and all of its valuables) in their bundle
                     if (valuablePreset.GetCombinedList().Count > 0)
                     {
-                        Logger.LogWarning($"Proxy preset \"{valuablePreset.name}\" in level \"{level.name}\" contains valuables! This might have caused duplicate valuables to load!");
+                        Logger.LogWarning($"Proxy preset \"{valuablePreset.name}\" in level \"{level.name}\" contains valuables! This likely caused duplicate valuables to load!");
                     }
                     
                     level.ValuablePresets[i] = foundPreset;

--- a/REPOLib/Modules/Levels.cs
+++ b/REPOLib/Modules/Levels.cs
@@ -1,0 +1,206 @@
+﻿using REPOLib.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace REPOLib.Modules;
+
+public static class Levels
+{
+    public static IReadOnlyList<Level> AllLevels => GetLevels();
+    public static IReadOnlyList<Level> RegisteredLevels => _levelsRegistered;
+    
+    private static readonly List<Level> _levelsToRegister = [];
+    private static readonly List<Level> _levelsRegistered = [];
+
+    private static bool _canRegisterLevels = true;
+
+    internal static void RegisterLevels()
+    {
+        if (!_canRegisterLevels)
+        {
+            return;
+        }
+        
+        ValuablePresets.CacheValuablePresets();
+
+        Logger.LogInfo($"Adding levels.");
+        
+        foreach (var level in _levelsToRegister)
+        {
+            if (_levelsRegistered.Contains(level))
+            {
+                continue;
+            }
+
+            if (level.ValuablePresets.Count == 0)
+            {
+                Logger.LogWarning($"Level \"{level.name}\" does not have any valuable presets! Adding generic preset.");
+                level.ValuablePresets.Add(ValuablePresets.GenericPreset);
+            }
+
+            for (int i = 0; i < level.ValuablePresets.Count; i++)
+            {
+                var valuablePreset = level.ValuablePresets[i];
+
+                if (ValuablePresets.AllValuablePresets.Values.Contains(valuablePreset))
+                {
+                    continue;
+                }
+                
+                if (ValuablePresets.AllValuablePresets.TryGetValue(valuablePreset.name, out var foundPreset))
+                {
+                    if (valuablePreset.GetCombinedList().Count > 0)
+                    {
+                        Logger.LogWarning($"Proxy preset \"{valuablePreset.name}\" in level \"{level.name}\" contains valuables! This might have caused duplicate valuables to load!");
+                    }
+                    
+                    level.ValuablePresets[i] = foundPreset;
+                    Logger.LogInfo($"Replaced proxy preset \"{valuablePreset.name}\" in level \"{level.name}\".", extended: true);
+                }
+                else
+                {
+                    ValuablePresets.RegisterValuablePreset(valuablePreset);
+                    Logger.LogInfo($"Registered valuable preset \"{valuablePreset.name}\" from \"{level.name}\".", extended: true);
+                }
+            }
+
+            RunManager.instance.levels.Add(level);
+            Logger.LogInfo($"Added level \"{level.name}\"", extended: true);
+            
+            _levelsRegistered.Add(level);
+        }
+
+        _levelsToRegister.Clear();
+        _canRegisterLevels = false;
+    }
+
+    public static void RegisterLevel(Level level)
+    {
+        if (level == null)
+        {
+            Logger.LogError($"Failed to register level. Level is null.");
+            return;
+        }
+
+        if (!_canRegisterLevels)
+        {
+            Logger.LogError($"Failed to register level \"{level.name}\". You can only register levels from your plugins awake!");
+            return;
+        }
+
+        /*
+        if (ResourcesHelper.HasValuablePrefab(valuableObject))
+        {
+            Logger.LogError($"Failed to register valuable \"{prefab.name}\". Valuable prefab already exists in Resources with the same name.");
+            return;
+        }
+        */
+
+        if (_levelsToRegister.Any(x => x.name.Equals(level.name, StringComparison.OrdinalIgnoreCase)))
+        {
+            Logger.LogError($"Failed to register level \"{level.name}\". Level already exists with the same name.");
+            return;
+        }
+
+        if (_levelsToRegister.Contains(level))
+        {
+            Logger.LogWarning($"Failed to register level \"{level.name}\". Level is already registered!");
+            return;
+        }
+
+        List<(GameObject, ResourcesHelper.LevelPrefabType)> modules =
+            new[]
+            {
+                level.ModulesExtraction1,
+                level.ModulesExtraction2,
+                level.ModulesExtraction3,
+                level.ModulesNormal1,
+                level.ModulesNormal2,
+                level.ModulesNormal3,
+                level.ModulesPassage1,
+                level.ModulesPassage2,
+                level.ModulesPassage3,
+                level.ModulesDeadEnd1,
+                level.ModulesDeadEnd2,
+                level.ModulesDeadEnd3
+            }
+                .SelectMany(list => list)
+                .Select(prefab => (prefab, ResourcesHelper.LevelPrefabType.Module))
+                .ToList();
+        
+        foreach (var prefab in level.StartRooms)
+        {
+            modules.Add((prefab, ResourcesHelper.LevelPrefabType.Module));
+        }
+
+        if (level.ConnectObject != null)
+        {
+            modules.Add((level.ConnectObject, ResourcesHelper.LevelPrefabType.Other));
+        }
+
+        if (level.BlockObject != null)
+        {
+            modules.Add((level.BlockObject, ResourcesHelper.LevelPrefabType.Other));
+        }
+        
+        foreach (var (prefab, type) in modules)
+        {
+            string prefabId = ResourcesHelper.GetLevelPrefabPath(level, prefab, type);
+            NetworkPrefabs.RegisterNetworkPrefab(prefabId, prefab);
+
+            Utilities.FixAudioMixerGroups(prefab);
+        }
+
+        _levelsToRegister.Add(level);
+    }
+
+    public static IReadOnlyList<Level> GetLevels()
+    {
+        if (RunManager.instance == null)
+        {
+            return [];
+        }
+
+        return RunManager.instance.levels;
+    }
+
+    public static bool TryGetLevelByName(string name, out Level level)
+    {
+        level = GetLevelByName(name);
+        return level != null;
+    }
+
+    public static Level GetLevelByName(string name)
+    {
+        foreach (var level in GetLevels())
+        {
+            if (level.name.EqualsAny([name, $"Level - {name}"], StringComparison.OrdinalIgnoreCase))
+            {
+                return level;
+            }
+        }
+
+        return default;
+    }
+
+    public static bool TryGetLevelThatContainsName(string name, out Level valuableObject)
+    {
+        valuableObject = GetLevelThatContainsName(name);
+        return valuableObject != null;
+    }
+
+    public static Level GetLevelThatContainsName(string name)
+    {
+        foreach (var level in GetLevels())
+        {
+            if (level.name.Contains(name, StringComparison.OrdinalIgnoreCase))
+            {
+                return level;
+            }
+        }
+
+        return default;
+    }
+}

--- a/REPOLib/Modules/Levels.cs
+++ b/REPOLib/Modules/Levels.cs
@@ -49,8 +49,10 @@ public static class Levels
                     continue;
                 }
                 
+                // This allows custom levels to use vanilla presets, by using a proxy preset with the same name
                 if (ValuablePresets.AllValuablePresets.TryGetValue(valuablePreset.name, out var foundPreset))
                 {
+                    // Check if the mod author accidentally included a vanilla preset (and all of its valuables) in their bundle
                     if (valuablePreset.GetCombinedList().Count > 0)
                     {
                         Logger.LogWarning($"Proxy preset \"{valuablePreset.name}\" in level \"{level.name}\" contains valuables! This might have caused duplicate valuables to load!");
@@ -89,15 +91,7 @@ public static class Levels
             Logger.LogError($"Failed to register level \"{level.name}\". You can only register levels from your plugins awake!");
             return;
         }
-
-        /*
-        if (ResourcesHelper.HasValuablePrefab(valuableObject))
-        {
-            Logger.LogError($"Failed to register valuable \"{prefab.name}\". Valuable prefab already exists in Resources with the same name.");
-            return;
-        }
-        */
-
+        
         if (_levelsToRegister.Any(x => x.name.Equals(level.name, StringComparison.OrdinalIgnoreCase)))
         {
             Logger.LogError($"Failed to register level \"{level.name}\". Level already exists with the same name.");
@@ -132,7 +126,7 @@ public static class Levels
         
         foreach (var prefab in level.StartRooms)
         {
-            modules.Add((prefab, ResourcesHelper.LevelPrefabType.Module));
+            modules.Add((prefab, ResourcesHelper.LevelPrefabType.StartRoom));
         }
 
         if (level.ConnectObject != null)
@@ -147,6 +141,8 @@ public static class Levels
         
         foreach (var (prefab, type) in modules)
         {
+            // maybe check if the prefab is already registered?
+            
             string prefabId = ResourcesHelper.GetLevelPrefabPath(level, prefab, type);
             NetworkPrefabs.RegisterNetworkPrefab(prefabId, prefab);
 

--- a/REPOLib/Modules/ResourcesHelper.cs
+++ b/REPOLib/Modules/ResourcesHelper.cs
@@ -33,6 +33,19 @@ public static class ResourcesHelper
     {
         return "Enemies/";
     }
+    
+    public static string GetLevelPrefabsFolderPath(Level level, LevelPrefabType type)
+    {
+        string folder = type switch
+        {
+            LevelPrefabType.Module => "Modules",
+            LevelPrefabType.Other => "Other",
+            LevelPrefabType.StartRoom => "Start Room",
+            _ => string.Empty
+        };
+        
+        return Path.Combine("Level", level.ResourcePath, folder);
+    }
     #endregion
 
     #region Paths
@@ -112,6 +125,25 @@ public static class ResourcesHelper
         }
 
         string folderPath = GetEnemiesFolderPath();
+
+        return Path.Combine(folderPath, prefab.name);
+    }
+
+    public enum LevelPrefabType
+    {
+        Module,
+        Other,
+        StartRoom
+    }
+    
+    public static string GetLevelPrefabPath(Level level, GameObject prefab, LevelPrefabType type)
+    {
+        if (prefab == null)
+        {
+            return string.Empty;
+        }
+
+        string folderPath = GetLevelPrefabsFolderPath(level, type);
 
         return Path.Combine(folderPath, prefab.name);
     }

--- a/REPOLib/Modules/ValuablePresets.cs
+++ b/REPOLib/Modules/ValuablePresets.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace REPOLib.Modules;
+
+public static class ValuablePresets
+{
+    public static IReadOnlyDictionary<string, LevelValuables> AllValuablePresets => _valuablePresets;
+    public static LevelValuables GenericPreset => AllValuablePresets[GenericValuablePresetName];
+    
+    private static readonly Dictionary<string, LevelValuables> _valuablePresets = [];
+    
+    public const string GenericValuablePresetName = "Valuables - Generic";
+    
+    public static void CacheValuablePresets()
+    {
+        if (RunManager.instance == null)
+        {
+            Logger.LogError($"Failed to cache LevelValuables. RunManager instance is null.");
+            return;
+        }
+
+        foreach (var level in RunManager.instance.levels)
+        {
+            foreach (var valuablePreset in level.ValuablePresets)
+            {
+                _valuablePresets.TryAdd(valuablePreset.name, valuablePreset);
+            }
+        }
+    }
+
+    internal static void RegisterValuablePreset(LevelValuables valuablePreset)
+    {
+        _valuablePresets.Add(valuablePreset.name, valuablePreset);
+    }
+}

--- a/REPOLib/Modules/Valuables.cs
+++ b/REPOLib/Modules/Valuables.cs
@@ -10,45 +10,17 @@ public static class Valuables
 {
     public static IReadOnlyList<GameObject> AllValuables => GetValuables();
     public static IReadOnlyList<GameObject> RegisteredValuables => _valuablesRegistered;
-    public static IReadOnlyList<LevelValuables> ValuablePresets => _valuablePresets.Values.ToList();
-
-    public static string GenericValuablePresetName => "Valuables - Generic";
     
-    private static readonly Dictionary<string, LevelValuables> _valuablePresets = [];
     private static readonly Dictionary<GameObject, List<string>> _valuablesToRegister = [];
     private static readonly List<GameObject> _valuablesRegistered = [];
 
     private static bool _canRegisterValuables = true;
-
-    private static void CacheValuablePresets()
-    {
-        if (RunManager.instance == null)
-        {
-            Logger.LogError($"Failed to cache LevelValuables. RunManager instance is null.");
-            return;
-        }
-
-        foreach (var level in RunManager.instance.levels)
-        {
-            foreach (var valuablePreset in level.ValuablePresets)
-            {
-                _valuablePresets.TryAdd(valuablePreset.name, valuablePreset);
-            }
-        }
-    }
+    
 
     internal static void RegisterValuables()
     {
         if (!_canRegisterValuables)
         {
-            return;
-        }
-
-        CacheValuablePresets();
-
-        if (_valuablePresets.Count == 0)
-        {
-            Logger.LogError($"Failed to register valuables. LevelValuables list is empty!");
             return;
         }
 
@@ -63,21 +35,21 @@ public static class Valuables
 
             List<string> presetNames = _valuablesToRegister[valuable];
 
-            if (!presetNames.Any(x => _valuablePresets.Keys.Any(y => x == y)))
+            if (!presetNames.Any(x => ValuablePresets.AllValuablePresets.Keys.Any(y => x == y)))
             {
                 Logger.LogError($"Valuable \"{valuable.name}\" does not have any valid valuable preset names set. Adding generic valuable preset name.");
-                presetNames.Add(GenericValuablePresetName);
+                presetNames.Add(ValuablePresets.GenericValuablePresetName);
             }
 
             foreach (var presetName in presetNames)
             {
-                if (presetName == null || !_valuablePresets.ContainsKey(presetName))
+                if (presetName == null || !ValuablePresets.AllValuablePresets.ContainsKey(presetName))
                 {
                     Logger.LogError($"Failed to add valuable \"{valuable.name}\" to valuable preset \"{presetName}\". The valuable preset does not exist.");
                     continue;
                 }
 
-                if (_valuablePresets[presetName].AddValuable(valuable))
+                if (ValuablePresets.AllValuablePresets[presetName].AddValuable(valuable))
                 {
                     _valuablesRegistered.Add(valuable);
                     Logger.LogInfo($"Added valuable \"{valuable.name}\" to valuable preset \"{presetName}\"", extended: true);
@@ -143,7 +115,7 @@ public static class Valuables
         if (presetNames == null || presetNames.Count == 0)
         {
             //Logger.LogInfo($"No valuable presets specified for valuable \"{prefab.name}\". Adding valuable to generic preset.", extended: true);
-            presetNames = [GenericValuablePresetName];
+            presetNames = [ValuablePresets.GenericValuablePresetName];
         }
 
         if (!_canRegisterValuables)
@@ -213,12 +185,7 @@ public static class Valuables
             return [];
         }
 
-        if (_valuablePresets.Count == 0)
-        {
-            CacheValuablePresets();
-        }
-
-        return _valuablePresets.Values
+        return ValuablePresets.AllValuablePresets.Values
             .Select(levelValuables => levelValuables.GetCombinedList())
             .SelectMany(list => list)
             .Distinct()

--- a/REPOLib/Objects/Sdk/LevelContent.cs
+++ b/REPOLib/Objects/Sdk/LevelContent.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace REPOLib.Objects.Sdk;
+
+[CreateAssetMenu(menuName = "REPOLib/Level", order = 4, fileName = "New Level")]
+public class LevelContent : Content
+{
+    [SerializeField]
+    private Level _level;
+    
+    public Level Level => _level;
+
+    public override string Name => Level.name;
+
+    public override void Initialize(Mod mod)
+    {
+        Modules.Levels.RegisterLevel(Level);
+    }
+}

--- a/REPOLib/Objects/Sdk/ValuableContent.cs
+++ b/REPOLib/Objects/Sdk/ValuableContent.cs
@@ -12,7 +12,7 @@ public class ValuableContent : Content
     private ValuableObject _prefab;
 
     [SerializeField]
-    private string[] _valuablePresets = [Valuables.GenericValuablePresetName];
+    private string[] _valuablePresets = [Modules.ValuablePresets.GenericValuablePresetName];
     
     public ValuableObject Prefab => _prefab;
     public IReadOnlyList<string> ValuablePresets => _valuablePresets;

--- a/REPOLib/Patches/RunManagerPatch.cs
+++ b/REPOLib/Patches/RunManagerPatch.cs
@@ -21,7 +21,7 @@ internal static class RunManagerPatch
 
         NetworkPrefabs.Initialize();
         NetworkingEvents.Initialize();
-        Levels.RegisterLevels();
+        Levels.RegisterInitialLevels();
         Valuables.RegisterInitialValuables();
 
         BundleLoader.OnAllBundlesLoaded += CommandManager.Initialize;

--- a/REPOLib/Patches/RunManagerPatch.cs
+++ b/REPOLib/Patches/RunManagerPatch.cs
@@ -19,6 +19,7 @@ internal static class RunManagerPatch
 
         NetworkPrefabs.Initialize();
         NetworkingEvents.Initialize();
+        Levels.RegisterLevels();
         Valuables.RegisterValuables();
 
         CommandManager.Initialize();


### PR DESCRIPTION
Adds a new `Levels` module. Currently a WIP with no docs, but I managed to successfully load a copy of one of the vanilla levels.

Note that this contains breaking changes as I extracted `ValuablePresets` from the valuable module to also use for levels.