### PR TITLE
Use debug log level for common events

### DIFF
--- a/REPOLib/BundleLoader.cs
+++ b/REPOLib/BundleLoader.cs
@@ -80,7 +80,7 @@ public static class BundleLoader
                     
                     if (progress.HasValue) msg += $" {progress.Value:P0}";
                     
-                    Logger.LogInfo(msg, extended: true);
+                    Logger.LogDebug(msg, extended: true);
                 }
             }
             

--- a/REPOLib/Commands/CommandManager.cs
+++ b/REPOLib/Commands/CommandManager.cs
@@ -29,7 +29,7 @@ internal static class CommandManager
         {
             try
             {
-                Logger.LogInfo($"Initializing command initializer on method {command.DeclaringType}.{command.Name}", extended: true);
+                Logger.LogDebug($"Initializing command initializer on method {command.DeclaringType}.{command.Name}", extended: true);
                 if (!command.IsStatic)
                 {
                     Logger.LogWarning($"Command initializer {command.DeclaringType}.{command.Name} is not static!");
@@ -88,7 +88,7 @@ internal static class CommandManager
             {
                 if (CommandExecutionMethods.TryAdd(aliasAttribute.Alias, method))
                 {
-                    Logger.LogInfo($"Registered command alias \"{aliasAttribute.Alias}\" for method \"{method.DeclaringType}.{method.Name}\".", extended: true);
+                    Logger.LogDebug($"Registered command alias \"{aliasAttribute.Alias}\" for method \"{method.DeclaringType}.{method.Name}\".", extended: true);
                     added = true;
                 }
             }

--- a/REPOLib/Extensions/AudioSourceExtensions.cs
+++ b/REPOLib/Extensions/AudioSourceExtensions.cs
@@ -66,6 +66,6 @@ public static class AudioSourceExtensions
 
         audioSource.outputAudioMixerGroup = audioMixerGroup;
 
-        Logger.LogInfo($"Fixed AudioMixerGroup on GameObject \"{fullGameObjectName}\". AudioMixerGroup \"{audioMixer.name}/{audioMixerGroup.name}\"", extended: true);
+        Logger.LogDebug($"Fixed AudioMixerGroup on GameObject \"{fullGameObjectName}\". AudioMixerGroup \"{audioMixer.name}/{audioMixerGroup.name}\"", extended: true);
     }
 }

--- a/REPOLib/Logger.cs
+++ b/REPOLib/Logger.cs
@@ -11,6 +11,11 @@ internal static class Logger
         ManualLogSource = manualLogSource;
     }
 
+    public static void LogDebug(object data, bool extended = true)
+    {
+        Log(LogLevel.Debug, data, extended);
+    }
+
     public static void LogInfo(object data, bool extended = false)
     {
         Log(LogLevel.Info, data, extended);

--- a/REPOLib/Modules/NetworkPrefabs.cs
+++ b/REPOLib/Modules/NetworkPrefabs.cs
@@ -30,7 +30,7 @@ public static class NetworkPrefabs
         }
 
         Logger.LogInfo($"Initializing NetworkPrefabs.");
-        Logger.LogInfo($"PhotonNetwork.PrefabPool = {PhotonNetwork.PrefabPool.GetType()}", extended: true);
+        Logger.LogDebug($"PhotonNetwork.PrefabPool = {PhotonNetwork.PrefabPool.GetType()}", extended: true);
 
         if (PhotonNetwork.PrefabPool is DefaultPool defaultPool)
         {
@@ -44,7 +44,7 @@ public static class NetworkPrefabs
         PhotonNetwork.PrefabPool = CustomPrefabPool;
 
         Logger.LogInfo("Replaced PhotonNetwork.PrefabPool with CustomPrefabPool.");
-        Logger.LogInfo($"PhotonNetwork.PrefabPool = {PhotonNetwork.PrefabPool.GetType()}", extended: true);
+        Logger.LogDebug($"PhotonNetwork.PrefabPool = {PhotonNetwork.PrefabPool.GetType()}", extended: true);
         Logger.LogInfo($"Finished initializing NetworkPrefabs.");
     }
 

--- a/REPOLib/Modules/Valuables.cs
+++ b/REPOLib/Modules/Valuables.cs
@@ -91,7 +91,7 @@ public static class Valuables
             if (_valuablePresets[presetName].AddValuable(valuable))
             {
                 _valuablesRegistered.Add(valuable);
-                Logger.LogInfo($"Added valuable \"{valuable.name}\" to valuable preset \"{presetName}\"", extended: true);
+                Logger.LogDebug($"Added valuable \"{valuable.name}\" to valuable preset \"{presetName}\"", extended: true);
             }
             else
             {

--- a/REPOLib/Objects/CustomPrefabPool.cs
+++ b/REPOLib/Objects/CustomPrefabPool.cs
@@ -63,7 +63,7 @@ public class CustomPrefabPool : IPunPrefabPool
 
         Prefabs[prefabId] = prefab;
 
-        Logger.LogInfo($"CustomPrefabPool: registered network prefab \"{prefabId}\"", extended: true);
+        Logger.LogDebug($"CustomPrefabPool: registered network prefab \"{prefabId}\"", extended: true);
         return true;
     }
 

--- a/REPOLib/Patches/EnemyBangDirectorPatch.cs
+++ b/REPOLib/Patches/EnemyBangDirectorPatch.cs
@@ -34,7 +34,7 @@ internal static class EnemyBangDirectorPatch
             {
                 // Replace original method call with replacement method call
                 modifiedInstructions.Add(new CodeInstruction(OpCodes.Call, replacementMethod));
-                Logger.LogInfo($"EnemyBangDirectorPatch: AwakeTranspiler replaced {originalMethod.Name} call with {replacementMethod.Name}.", extended: true);
+                Logger.LogDebug($"EnemyBangDirectorPatch: AwakeTranspiler replaced {originalMethod.Name} call with {replacementMethod.Name}.", extended: true);
                 continue;
             }
 

--- a/REPOLib/Patches/EnemyGnomeDirectorPatch.cs
+++ b/REPOLib/Patches/EnemyGnomeDirectorPatch.cs
@@ -34,7 +34,7 @@ internal static class EnemyGnomeDirectorPatch
             {
                 // Replace original method call with replacement method call
                 modifiedInstructions.Add(new CodeInstruction(OpCodes.Call, replacementMethod));
-                Logger.LogInfo($"EnemyGnomeDirectorPatch: AwakeTranspiler replaced {originalMethod.Name} call with {replacementMethod.Name}.", extended: true);
+                Logger.LogDebug($"EnemyGnomeDirectorPatch: AwakeTranspiler replaced {originalMethod.Name} call with {replacementMethod.Name}.", extended: true);
                 continue;
             }
 


### PR DESCRIPTION
Uses the `Debug` log level for some of the more spammy logs. In my opinion this is much easier to look at and process.

![screenshot](https://github.com/user-attachments/assets/46eb432a-d76f-4dab-9062-8c617af3154d)
