### PR TITLE
Added safety for GetCustomAttribute

### DIFF
--- a/REPOLib/Commands/CommandManager.cs
+++ b/REPOLib/Commands/CommandManager.cs
@@ -22,7 +22,7 @@ internal static class CommandManager
 
         CommandInitializerMethods = AccessTools.AllTypes()
             .SelectMany(type => type.SafeGetMethods())
-            .Where(method => method.GetCustomAttribute<CommandInitializerAttribute>() != null)
+            .Where(method => method.HasCustomAttribute<CommandInitializerAttribute>())
             .ToList();
 
         foreach (var command in CommandInitializerMethods)
@@ -61,7 +61,7 @@ internal static class CommandManager
     {
         _commandExecutionMethodCache = AccessTools.AllTypes()
             .SelectMany(type => type.SafeGetMethods())
-            .Where(method => method.GetCustomAttribute<CommandExecutionAttribute>() != null)
+            .Where(method => method.HasCustomAttribute<CommandExecutionAttribute>())
             .ToList();
 
         foreach (var method in _commandExecutionMethodCache)

--- a/REPOLib/Extensions/ReflectionExtensions.cs
+++ b/REPOLib/Extensions/ReflectionExtensions.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 
 namespace REPOLib.Extensions;
 
-internal static class TypeExtensions
+internal static class ReflectionExtensions
 {
     public static IEnumerable<MethodInfo> SafeGetMethods(this Type type)
     {
@@ -17,5 +17,18 @@ internal static class TypeExtensions
             // Logger.LogWarning($"Error retrieving methods for type {type.FullName}: {ex.Message}");
             return Array.Empty<MethodInfo>();
         }
+    }
+
+    public static T? SafeGetCustomAttribute<T>(this MethodInfo method)
+    {
+        try
+        {
+            return method.GetCustomAttribute<T>();
+        }
+        catch /*(Exception ex)*/
+        {
+            // Logger.LogWarning($"Error retrieving methods for type {type.FullName}: {ex.Message}");
+            return null;
+        }   
     }
 }

--- a/REPOLib/Extensions/ReflectionExtensions.cs
+++ b/REPOLib/Extensions/ReflectionExtensions.cs
@@ -4,8 +4,17 @@ using System.Reflection;
 
 namespace REPOLib.Extensions;
 
+
+/// <summary>
+/// We add these extensions because we don't care about the reflection errors, and we can safely ignore them.
+/// </summary>
 internal static class ReflectionExtensions
 {
+    /// <summary>
+    /// A safe way to get all methods from a type.
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns></returns>
     public static IEnumerable<MethodInfo> SafeGetMethods(this Type type)
     {
         try
@@ -19,7 +28,13 @@ internal static class ReflectionExtensions
         }
     }
 
-    public static T? SafeGetCustomAttribute<T>(this MethodInfo method)
+    /// <summary>
+    /// A safe way to get a custom attribute from a method.
+    /// </summary>
+    /// <param name="method"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static T? SafeGetCustomAttribute<T>(this MethodInfo method) where T : Attribute
     {
         try
         {
@@ -30,5 +45,24 @@ internal static class ReflectionExtensions
             // Logger.LogWarning($"Error retrieving methods for type {type.FullName}: {ex.Message}");
             return null;
         }   
+    }
+    
+    /// <summary>
+    /// A safe way to check if a method has a custom attribute.
+    /// </summary>
+    /// <param name="method"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static bool HasCustomAttribute<T>(this MethodInfo method) where T : Attribute
+    {
+        try
+        {
+            return method.GetCustomAttribute<T>() != null;
+        }
+        catch /*(Exception ex)*/
+        {
+            // Logger.LogWarning($"Error retrieving methods for type {type.FullName}: {ex.Message}");
+            return false;
+        }
     }
 }


### PR DESCRIPTION
As seen in #37 GetCustomAttributes requires a safety wrapping. Once again, when these methods fail, we likely do not care and can safely continue and ignore any errors. This prevents total failure of REPOLib.

[AUTOGENERATED]
This pull request includes changes to improve the handling of reflection methods and custom attributes, as well as some code cleanup. The most important changes are the introduction of new reflection extension methods and the removal of redundant code.

Reflection improvements:

* [`REPOLib/Extensions/ReflectionExtensions.cs`](diffhunk://#diff-a1e34178d33d43df4c9e70147323e14d16cecfb671a06349555f74825a6754b2R1-R68): Added new extension methods `SafeGetMethods`, `SafeGetCustomAttribute`, and `HasCustomAttribute` to handle reflection errors safely.

Code cleanup:

* [`REPOLib/Commands/CommandManager.cs`](diffhunk://#diff-ba16a6ca747723b07f60f878ac10e884c491e6a4eab0679b40cf1911e64ddb8aL25-R25): Updated `Initialize` and `FindAllCommandMethods` methods to use `HasCustomAttribute` instead of `GetCustomAttribute` for checking custom attributes. [[1]](diffhunk://#diff-ba16a6ca747723b07f60f878ac10e884c491e6a4eab0679b40cf1911e64ddb8aL25-R25) [[2]](diffhunk://#diff-ba16a6ca747723b07f60f878ac10e884c491e6a4eab0679b40cf1911e64ddb8aL64-R64)
* [`REPOLib/Extensions/TypeExtensions.cs`](diffhunk://#diff-228635c5cc4ae649b57555a967f289deab94c50f459598ee909850dd2316582eL1-L21): Removed the `SafeGetMethods` method as it has been moved to `ReflectionExtensions`.