### PR TITLE
Add Command to List All Commands

### DIFF
--- a/REPOLib/Commands/ListCommandsCommand.cs
+++ b/REPOLib/Commands/ListCommandsCommand.cs
@@ -11,7 +11,7 @@ internal static class ListCommandsCommand
         requiresDeveloperMode: false
     )]
     [CommandAlias("listcommands")]
-    [CommandAlias("listcom")]
+    [CommandAlias("commands")]
     [CommandAlias("lc")]
     public static void Execute(string args)
     {

--- a/REPOLib/Commands/ListCommandsCommand.cs
+++ b/REPOLib/Commands/ListCommandsCommand.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace REPOLib.Commands;
+
+internal static class ListCommandsCommand
+{
+    [CommandExecution(
+        "List Commands",
+        "Lists all commands with their name, aliases, and descriptions in the log",
+        requiresDeveloperMode: false
+    )]
+    [CommandAlias("listcommands")]
+    [CommandAlias("listcom")]
+    [CommandAlias("lc")]
+    public static void Execute(string args)
+    {
+        Logger.LogInfo($"Running command lister", extended: true);
+        
+        List<(int,string,List<string>,string)> activeCommands = [];
+        foreach (var commandExecutionInfo in CommandManager.CommandExecutionMethods)
+        {
+            var metadataToken = commandExecutionInfo.Value.MetadataToken;
+            if (activeCommands.Exists(x => x.Item1 == metadataToken))
+            {
+                activeCommands.First(x => x.Item1 == metadataToken)
+                    .Item3.Add(commandExecutionInfo.Key);
+                continue;
+            }
+            
+            var attributeData = commandExecutionInfo.Value.CustomAttributes.First(x =>
+                x.AttributeType == typeof(CommandExecutionAttribute));
+            
+            var name = attributeData.ConstructorArguments[0].Value as string;
+            var description = attributeData.ConstructorArguments[1].Value as string;
+            
+            activeCommands.Add((metadataToken,name,[commandExecutionInfo.Key],description)!);
+        }
+        
+        Logger.LogInfo("Commands:");
+        foreach (var listedCommand in activeCommands)
+        {
+            var aliases = string.Join(", ", listedCommand.Item3);
+            Logger.LogInfo("   " + $"{listedCommand.Item2} (Aliases: {aliases}): {listedCommand.Item4}");
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a command which creates a list of command names, aliases, and descriptions.

I'm not sure if this project allows adding commands directly but I think this would be a good addition that could be used by players and developers.

Please comment if you see anything that could use some changes.