### PR TITLE
Adding Module Registration support to allow for adding rooms to existing maps

### DIFF
--- a/REPOLib/Modules/Modules.cs
+++ b/REPOLib/Modules/Modules.cs
@@ -1,0 +1,211 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace REPOLib.Modules;
+
+/// <summary>
+/// The Modules module of REPOLib.
+/// </summary>
+public static class Modules
+{
+    /// <summary>
+    /// The three different difficulty levels modules spawn at. 
+    /// </summary>
+    [System.Flags]
+    public enum Difficulty
+    {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        One = 1,
+        Two = 2,
+        Three = 4,
+        All = One | Two | Three,
+        None = 0,
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+    }
+    
+    /// <summary>
+    /// Defines the type of a module.
+    /// </summary>
+    public enum Type
+    {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        Normal,
+        Passage,
+        DeadEnd,
+        Extraction,
+        StartRoom,
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+    }
+
+    /// <summary>
+    /// A struct containing the information necessary to add modules into existing levels.
+    /// </summary>
+    public struct ModuleRegistrationInfo
+    {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        public Module module;
+        public Type type;
+        public Difficulty difficulty;
+        public List<string> targetLevels;
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+
+        /// <summary>
+        /// Constructor for a <see cref="ModuleRegistrationInfo"/> struct.
+        /// </summary>
+        /// <param name="module">The <see cref="Module"/> to register.</param>
+        /// <param name="type">The <see cref="Type"/> of the <see cref="Module"/></param>
+        /// <param name="difficulty">The <see cref="Difficulty"/> or difficulties the <see cref="Module"/> should be registered to.</param>
+        /// <param name="targetLevels">The ResourcePath of the level this module should be registered to.</param>
+        public ModuleRegistrationInfo(Module module, Type type, Difficulty difficulty, List<string> targetLevels)
+        {
+            this.module = module;
+            this.type = type;
+            this.difficulty = difficulty;
+            this.targetLevels = targetLevels;
+        }
+    }
+    
+    /// <summary>
+    /// Get all levels registered with REPOLib.
+    /// </summary>
+    public static IReadOnlyList<Module> RegisteredModules => _modulesRegistered;
+
+    private static readonly List<ModuleRegistrationInfo> _modulesToRegister = [];
+    private static readonly List<Module> _modulesRegistered = [];
+
+    private static bool _initialModulesRegistered;
+
+    internal static void RegisterInitialModules()
+    {
+        if (_initialModulesRegistered)
+        {
+            return;
+        }
+
+        Logger.LogInfo($"Adding modules.");
+
+        foreach (var module in _modulesToRegister)
+        {
+            RegisterModuleWithGame(module);
+        }
+
+        _modulesToRegister.Clear();
+        _initialModulesRegistered = true;
+    }
+    
+    static void RegisterModuleWithGame(ModuleRegistrationInfo info)
+    {
+        foreach (var targetLevelName in info.targetLevels)
+        {
+            Level? targetLevel = Levels.GetLevelByName(targetLevelName);
+            
+            if (!targetLevel)
+            {
+                Logger.LogError($"Failed to register module \"{info.module.name}\" to level \"{targetLevelName}\". Could not find a level with a matching name.");
+                continue;
+            }
+            
+            RegisterModuleToLevel(info.module, info.type, info.difficulty, targetLevel!);
+        }
+    }
+    
+    /// <summary>
+    /// Registers a <see cref="Module"/>.
+    /// </summary>
+    /// <param name="info">The <see cref="ModuleRegistrationInfo"/> to register.</param>
+    public static void RegisterModule(ModuleRegistrationInfo info)
+    {
+        if (!info.module)
+        {
+            Logger.LogError($"Failed to register module. Module is null.");
+            return;
+        }
+
+        if (info.difficulty.HasFlag(Difficulty.None) && info.type != Type.StartRoom)
+        {
+            Logger.LogError($"Failed to register module \"{info.module.name}\". Module has no assigned difficulty, and is not a Start Room.");
+            return;
+        }
+
+        if (info.targetLevels == null || info.targetLevels.Count == 0)
+        {
+            Logger.LogError($"Failed to register module \"{info.module.name}\". Module has no levels to be assigned to.");
+        }
+
+        string prefabId = ResourcesHelper.GetModulePrefabPath(info.module.gameObject);
+        
+        if (!_modulesRegistered.Contains(info.module) && !ResourcesHelper.HasPrefab(prefabId))
+        {
+            NetworkPrefabs.RegisterNetworkPrefab(prefabId, info.module.gameObject);
+            Utilities.FixAudioMixerGroups(info.module.gameObject);
+        }
+
+        if (_initialModulesRegistered)
+        {
+            RegisterModuleWithGame(info);
+        }
+        else
+        {
+            _modulesToRegister.Add(info);
+        }
+    }
+    
+    private static void RegisterModuleToLevel(Module module, Type type, Difficulty difficulty, Level level)
+    {
+        switch (type)
+        {
+            case Type.Normal: 
+                RegisterModuleToLevelUsingCategory(module, type, difficulty, level, 
+                    ref level.ModulesNormal1, ref level.ModulesNormal2, ref level.ModulesNormal3); 
+                break;
+            case Type.Passage:
+                RegisterModuleToLevelUsingCategory(module, type, difficulty, level, 
+                    ref level.ModulesPassage1, ref level.ModulesPassage2, ref level.ModulesPassage3); 
+                break;
+            case Type.DeadEnd:
+                RegisterModuleToLevelUsingCategory(module, type, difficulty, level, 
+                    ref level.ModulesDeadEnd1, ref level.ModulesDeadEnd2, ref level.ModulesDeadEnd3); 
+                break;
+            case Type.Extraction:
+                RegisterModuleToLevelUsingCategory(module, type, difficulty, level, 
+                    ref level.ModulesExtraction1, ref level.ModulesExtraction2, ref level.ModulesExtraction3); 
+                break;
+            case Type.StartRoom:
+                if (!level.StartRooms.Contains(module.gameObject))
+                {
+                    level.StartRooms.Add(module.gameObject);
+                    Logger.LogInfo($"Added module \"{module.name}\" to \"{level.name}\" in \"{type.ToString()}\" category.", extended: true);
+                } 
+                else
+                {
+                    Logger.LogWarning($"Module \"{module.name}\" is already registered to \"{level.name}\" in \"{type.ToString()}\" category.");
+                }
+                break;
+        }
+    }
+
+    private static void RegisterModuleToLevelUsingCategory(Module module, Type type, Difficulty difficulty, Level level,
+        ref List<GameObject> dif1, ref List<GameObject> dif2, ref List<GameObject> dif3)
+    {
+        if (difficulty.HasFlag(Difficulty.One))
+            RegisterModuleToList(module, type, 1, level, ref dif1);
+        if (difficulty.HasFlag(Difficulty.Two))
+            RegisterModuleToList(module, type, 2, level, ref dif2);
+        if (difficulty.HasFlag(Difficulty.Three))
+            RegisterModuleToList(module, type, 3, level, ref dif3);
+    }
+
+    private static void RegisterModuleToList(Module module, Type type, int difficulty, Level level,
+        ref List<GameObject> list)
+    {
+        if (!list.Contains(module.gameObject))
+        {
+            list.Add(module.gameObject);
+            Logger.LogInfo($"Added module \"{module.name}\" to \"{level.name}\" difficulty {difficulty} in \"{type.ToString()}\" category.", extended: true);
+        }
+        else
+        {
+            Logger.LogWarning($"Module \"{module.name}\" is already registered to \"{level.name}\" difficulty {difficulty} in \"{type.ToString()}\" category.");
+        }
+    }
+}

--- a/REPOLib/Modules/ResourcesHelper.cs
+++ b/REPOLib/Modules/ResourcesHelper.cs
@@ -35,6 +35,11 @@ public static class ResourcesHelper
         return "Enemies";
     }
 
+    public static string GetModulesFolderPath()
+    {
+        return "MiscModules";
+    }
+    
     public static string GetLevelPrefabsFolderPath(Level level, LevelPrefabType type)
     {
         string folder = type switch
@@ -130,6 +135,18 @@ public static class ResourcesHelper
         return $"{folderPath}/{prefab.name}";
     }
 
+    public static string GetModulePrefabPath(GameObject prefab)
+    {
+        if (prefab == null)
+        {
+            return string.Empty;
+        }
+
+        string folderPath = GetModulesFolderPath();
+
+        return $"{folderPath}/{prefab.name}";
+    }
+    
     public enum LevelPrefabType
     {
         Module,

--- a/REPOLib/Objects/Sdk/ModuleContent.cs
+++ b/REPOLib/Objects/Sdk/ModuleContent.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace REPOLib.Objects.Sdk;
+
+/// <summary>
+/// REPOLib ModuleContent class.
+/// </summary>
+[CreateAssetMenu(menuName = "REPOLib/Module", order = 4, fileName = "New Module")]
+public class ModuleContent : Content
+{
+    #pragma warning disable CS0649 // Field 'field' is never assigned to, and will always have its default value 'value'
+    [SerializeField]
+    private Module _prefab = null!;
+    #pragma warning restore CS0649 // Field 'field' is never assigned to, and will always have its default value 'value'
+
+    [SerializeField] 
+    private Modules.Modules.Type _type = Modules.Modules.Type.Normal;
+    
+    [SerializeField]
+    private Modules.Modules.Difficulty _difficulties = Modules.Modules.Difficulty.None;
+
+    [SerializeField] 
+    private List<string> _targetLevels = [];
+    
+    /// <summary>
+    /// The <see cref="global::Module"/> of this content.
+    /// </summary>
+    public Module Prefab => _prefab;
+
+    /// <summary>
+    /// The name of the <see cref="Module"/>
+    /// </summary>
+    public override string Name => Prefab?.name ?? string.Empty;
+
+    /// <summary>
+    /// The type of the <see cref="Module"/>
+    /// </summary>
+    public Modules.Modules.Type Type => _type;
+    
+    /// <summary>
+    /// The <see cref="Modules.Modules.Difficulty"/> at which this module will be generated at.
+    /// </summary>
+    public Modules.Modules.Difficulty Difficulty => _difficulties;
+    
+    /// <summary>
+    /// The names of the Levels that this module should be added to
+    /// </summary>
+    public List<string> TargetLevels => _targetLevels;
+    
+    /// <inheritdoc/>
+    public override void Initialize(Mod mod)
+    {
+        Modules.Modules.RegisterModule(new REPOLib.Modules.Modules.ModuleRegistrationInfo(Prefab, Type, Difficulty, TargetLevels));
+    }
+}

--- a/REPOLib/Patches/RunManagerPatch.cs
+++ b/REPOLib/Patches/RunManagerPatch.cs
@@ -22,6 +22,7 @@ internal static class RunManagerPatch
         NetworkPrefabs.Initialize();
         NetworkingEvents.Initialize();
         Levels.RegisterInitialLevels();
+        Modules.Modules.RegisterInitialModules();
         Valuables.RegisterInitialValuables();
 
         BundleLoader.OnAllBundlesLoaded += CommandManager.Initialize;


### PR DESCRIPTION
### Purpose
This PR hopes to give modders the ability to add new modules (rooms) to existing maps. Several people on the REPO Modding discord have asked for this functionality, including myself, so I've done my best at creating a first-pass that can be further improved upon.

The way in which I have implemented adding new modules made the most sense to me given the way they are assigned to levels in vanilla REPO. I am happy to discuss any issues that there may be with my approach, as I would love to get Module Registering functionality into REPOLib in a way that that can empower modders to create more cool mods easily!

### How to use
A new "Module" asset can be created in the SDK. This has several parameters:
- `Module`: A reference to the Module prefab that will be added to the chosen levels
- `Type`: Each module has a type. The possible types are:
  - `Normal`
  - `Passage`
  - `DeadEnd`
  - `Extraction`
  - `StartRoom`
- `Difficulty`: This determines at which difficulties this module will appear in the level. Note that this *does not* affect Modules with the `StartRoom` type.
- `TargetLevels`: The `ResourcePath` string name for each level that this module should be added to.

Alternatively, the `RegisterModule` function on the `Modules` class can be used to register a module using the API. This is all done in a similar way to how Levels are registered through REPOLib.

### Naming discussion
As rooms are called "Modules" inside REPO, I have continued that naming convention here, though this does make some code a bit difficult to read, as there is now a "Modules" module in REPOLib. I personally believe this is a fairly small issue that will not be seen by modders using REPOLib, but if others have suggestions for how to improve this, I'd be happy to implement them in this PR.